### PR TITLE
CHANGELOG.md: update CHANGELOG for v7.3 CANFD fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 本Change Logのフォーマットは [Keep a Changelog](http://keepachangelog.com/) に基づいています。
 
+## [v7.3] - 2025-07-21
+### Fixed
+- CANFDの問題を修正
+
 ## [v7.2] - 2025-06-17
 ### Fixed
 - kakip_ai_appsが実行できない問題を修正


### PR DESCRIPTION
Added a new section for version v7.3 dated 2025-07-21. Documented the fix for the CANFD issue under the "Fixed" category.